### PR TITLE
fix(rni): two-packet write txdat send trigger lost

### DIFF
--- a/rtl/src/rni/rni_awctrl.v
+++ b/rtl/src/rni/rni_awctrl.v
@@ -307,6 +307,7 @@ module rni_awctrl `RNI_PARAM
     reg [RNI_AW_ENTRIES_NUM_PARAM-1:0]          txdat_rdy_entry_d3_q;
     reg [RNI_AW_ENTRIES_NUM_PARAM-1:0]          txdat_select_vec_d3_q;
     reg [RNI_AW_ENTRIES_NUM_PARAM-1:0]          txdat_send_vec_q;
+    reg [RNI_AW_ENTRIES_NUM_PARAM-1:0]          txdat_send_pending_q;
     reg [`CHIE_RSP_FLIT_TXNID_WIDTH-1:0]        aw_txrsp_txnid_r;
     reg [`CHIE_RSP_FLIT_WIDTH-1:0]              aw_txrspflit_info_r;
     reg [RNI_AW_ENTRIES_NUM_PARAM-1:0]          txrsp_select_ptr_q;
@@ -1202,7 +1203,14 @@ module rni_awctrl `RNI_PARAM
            ~(txdat_select_vec_w[RNI_AW_ENTRIES_NUM_PARAM-1:0] & {RNI_AW_ENTRIES_NUM_PARAM{txdat_select_entry_two_packets_w}});
     //When alloc the entry, if there are two dat packets,awctrl_entry_two_packets_flag_q is assert, and when the entry is dealloc, awctrl_entry_two_packets_flag_q is deassert
     assign awctrl_entry_two_packets_flag_ns_w[RNI_AW_ENTRIES_NUM_PARAM-1:0] = (awctrl_entry_two_packets_flag_q[RNI_AW_ENTRIES_NUM_PARAM-1:0] | (awctrl_alloc_ptr_s2_q[RNI_AW_ENTRIES_NUM_PARAM-1:0] & {RNI_AW_ENTRIES_NUM_PARAM{txdat_two_packets_s2_w}})) & ~awctrl_entry_dealloc_vec_w[RNI_AW_ENTRIES_NUM_PARAM-1:0];
-    assign txdat_send_vec_ns_w[RNI_AW_ENTRIES_NUM_PARAM-1:0] = (txdat_send_vec_q[RNI_AW_ENTRIES_NUM_PARAM-1:0] | ({RNI_AW_ENTRIES_NUM_PARAM{awctrl_txdat_not_busy_d2_i}} & txdat_rdy_entry_d3_q[RNI_AW_ENTRIES_NUM_PARAM-1:0] & txdat_select_vec_d3_q[RNI_AW_ENTRIES_NUM_PARAM-1:0])) & ~awctrl_entry_dealloc_vec_w[RNI_AW_ENTRIES_NUM_PARAM-1:0];//txdat_select_vec_d3_q prevents a second packet
+    // For two-packet entries, rdy_d3 & sel_d3 may both assert while
+    // not_busy_d2 is still low (wr_buffer assembling the first flit).
+    // By the time not_busy_d2 reasserts, rdy_d3 has already been cleared,
+    // so the send trigger for the second packet is lost.
+    // Fix: latch the trigger in txdat_send_pending_q until not_busy_d2
+    // allows it to propagate into txdat_send_vec.
+    wire [RNI_AW_ENTRIES_NUM_PARAM-1:0] txdat_send_trigger_w = txdat_rdy_entry_d3_q[RNI_AW_ENTRIES_NUM_PARAM-1:0] & txdat_select_vec_d3_q[RNI_AW_ENTRIES_NUM_PARAM-1:0];
+    assign txdat_send_vec_ns_w[RNI_AW_ENTRIES_NUM_PARAM-1:0] = (txdat_send_vec_q[RNI_AW_ENTRIES_NUM_PARAM-1:0] | ({RNI_AW_ENTRIES_NUM_PARAM{awctrl_txdat_not_busy_d2_i}} & (txdat_send_trigger_w | txdat_send_pending_q))) & ~awctrl_entry_dealloc_vec_w[RNI_AW_ENTRIES_NUM_PARAM-1:0];
     assign awctrl_txdat_ccid_d2_o = {`CHIE_DAT_FLIT_CCID_WIDTH{1'b0}};
     assign awctrl_txdat_compack_d2_o = 1'b0;
     assign awctrl_txdat_rdy_v_d2_o = txdat_rdy_v_d2_q;
@@ -1368,6 +1376,16 @@ module rni_awctrl `RNI_PARAM
             end
         end
     end
+
+    always @(posedge clk_i or posedge rst_i) begin
+        if (rst_i == 1'b1)begin
+            txdat_send_pending_q[RNI_AW_ENTRIES_NUM_PARAM-1:0] <= {RNI_AW_ENTRIES_NUM_PARAM{1'b0}};
+        end
+        else begin
+            txdat_send_pending_q[RNI_AW_ENTRIES_NUM_PARAM-1:0] <= (txdat_send_pending_q[RNI_AW_ENTRIES_NUM_PARAM-1:0] | txdat_send_trigger_w[RNI_AW_ENTRIES_NUM_PARAM-1:0]) & ~txdat_send_vec_q[RNI_AW_ENTRIES_NUM_PARAM-1:0] & ~awctrl_entry_dealloc_vec_w[RNI_AW_ENTRIES_NUM_PARAM-1:0];
+        end
+    end
+
     /////////////////////////////////////////////////////////////
     // txrsp
     /////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Problem

In `rni_awctrl`, for two-packet write entries (e.g. 64B write = 2x32B CHI data flits), the second packet's send trigger (`txdat_rdy_entry_d3_q & txdat_select_vec_d3_q`) may assert while `awctrl_txdat_not_busy_d2_i` is still low, because the write buffer is still assembling the first flit. By the time `not_busy_d2` reasserts, `rdy_d3` has already been cleared. This causes `txdat_send_vec` to never be set for the second packet, and the write transaction hangs.

## Root Cause

The original combinational assign gates the send trigger with `not_busy_d2`, but `rdy_d3` is only high for one cycle. When these two signals do not overlap, the trigger is lost.

**Before:**
```verilog
assign txdat_send_vec_ns_w = (txdat_send_vec_q
    | ({N{awctrl_txdat_not_busy_d2_i}} & txdat_rdy_entry_d3_q & txdat_select_vec_d3_q))
    & ~awctrl_entry_dealloc_vec_w;
```

## Fix

Add a `txdat_send_pending_q` register that latches `(rdy_d3 & sel_d3)` and holds it until `not_busy_d2` allows propagation into `txdat_send_vec`. The pending bit is cleared once `txdat_send_vec` is set or the entry is deallocated.

**After:**
```verilog
wire txdat_send_trigger_w = txdat_rdy_entry_d3_q & txdat_select_vec_d3_q;

// latch trigger until not_busy_d2 allows propagation
reg  txdat_send_pending_q;
always @(posedge clk_i or posedge rst_i)
    txdat_send_pending_q <= rst_i ? 0
        : (txdat_send_pending_q | txdat_send_trigger_w)
          & ~txdat_send_vec_q & ~awctrl_entry_dealloc_vec_w;

assign txdat_send_vec_ns_w = (txdat_send_vec_q
    | ({N{awctrl_txdat_not_busy_d2_i}} & (txdat_send_trigger_w | txdat_send_pending_q)))
    & ~awctrl_entry_dealloc_vec_w;
```

Affected file: `rtl/src/rni/rni_awctrl.v`